### PR TITLE
fix: 'python black' format

### DIFF
--- a/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
+++ b/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
@@ -3125,7 +3125,9 @@ class BareosVADPWrapper(object):
 
         for vm in all_vms:
             if isinstance(vm.config, type(None)):
-                bareosfd.DebugMessage(100,"cannot read vm.config from VM %s\n" % (vm.name))
+                bareosfd.DebugMessage(
+                    100, "cannot read vm.config from VM %s\n" % (vm.name)
+                )
                 continue
 
             for dev in vm.config.hardware.device:


### PR DESCRIPTION
 ✗  bareos-check-sources --since=12624050ca36025cac38db74fcbd84907983191a reported:
	Plugin 'python black' would modify core/src/plugins/filed/python/vmware/bareos-fd-vmware.py'